### PR TITLE
style: clean up methods.hpp and update CMake configuration

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,7 +5,10 @@
             "name": "debug",
             "binaryDir": "build/${presetName}",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug"
+                "CMAKE_BUILD_TYPE": "Debug",
+                "XCMIXIN_BUILD_EXAMPLES": false,
+                "BUILD_EXAMPLES": true,
+                "BUILD_TESTING": true
             }
         },
         {
@@ -13,9 +16,10 @@
             "inherits": [
                 "debug"
             ],
-            "binaryDir": "build/${presetName}",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "MinSizeRel"
+                "CMAKE_BUILD_TYPE": "MinSizeRel",
+                "BUILD_EXAMPLES": false,
+                "BUILD_TESTING": false
             }
         }
     ]

--- a/xcmath/methods.hpp
+++ b/xcmath/methods.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#include <vcruntime_typeinfo.h>
-
 #include <cstddef>
 #include <type_traits>
 
@@ -22,7 +20,9 @@ XCMIXIN_DEF_BEGIN(clone_method)
 inline constexpr auto clone() const noexcept { return xcmixin_const_self; }
 XCMIXIN_DEF_END()
 XCMIXIN_DEF_BEGIN(move_method)
-inline constexpr decltype(auto) move() noexcept { return std::move(xcmixin_self); }
+inline constexpr decltype(auto) move() noexcept {
+    return std::move(xcmixin_self);
+}
 XCMIXIN_DEF_END()
 XCMIXIN_DEF_BEGIN(module_method)
 inline constexpr auto module() const noexcept {
@@ -362,4 +362,3 @@ using vec_member_methods_recorder = xcmixin::mixin_recorder<
     round_method, fract_method, sign_method, equal_method, less_than_method,
     greater_than_method, any_method, all_method>;
 }  // namespace xcmath
-


### PR DESCRIPTION
- Remove unnecessary vcruntime_typeinfo.h include
- Format move() method implementation
- Add build configuration variables to CMakePresets.json